### PR TITLE
Improve PHPUnit fixtures and require-dev setting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,16 +10,19 @@
     ],
 
     "require" : {
-        "php" : "^7.2",
+        "php" : "^7.2"
+    },
+
+    "require-dev": {
         "phpunit/phpunit": "^8.3"
     },
 
     "autoload"   : {
         "psr-4"  : {
             "Vstat\\" : "src/Vstat/"
-        } 
+        }
     },
-    
+
     "autoload-dev" : {
         "psr-4": {
             "Tests\\": "tests/"

--- a/tests/Unit/DataFilterTest.php
+++ b/tests/Unit/DataFilterTest.php
@@ -25,7 +25,7 @@ class DataFilterTest extends TestCase
     /**
      * setting up our test object.
      */
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->dataFilter = new DataFilter();
     }

--- a/tests/Unit/DataParserTest.php
+++ b/tests/Unit/DataParserTest.php
@@ -35,7 +35,7 @@ class DataParserTest extends TestCase
     /**
      * setting up our test object.
      */
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->parser = new DataParser();
     }

--- a/tests/Unit/DataTrimmerTest.php
+++ b/tests/Unit/DataTrimmerTest.php
@@ -23,7 +23,7 @@ use Vstat\App\DataTrimmer;
  */
 class DataTrimmerTest extends TestCase
 {
-    public function setUp() : void
+    protected function setUp() : void
     {
         $this->dataTrimmer = new DataTrimmer();
         $this->parser = new DataParser();


### PR DESCRIPTION
# Changed log

- According to the official [PHPUnit doc](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp` method.
- Improve `phpunit.xml` setting file.